### PR TITLE
TLS client authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This repo is a drop-in replacement of `golang.org/x/oauth2`
 It extends the original library with additional authentication methods:
 
 - private_key_jwt
+- tls_client_auth
+- self_signed_tls_client_auth
 
 ## Installation
 
@@ -17,7 +19,7 @@ When using go modules you can run:
 When using any of the originally supported authentication methods, there's no need to change anything.
 This library can be used as a drop-in replacement.
 
-For new authentication methods see:
+For new authentication methods see the examples below:
 
 ### Private Key JWT
 
@@ -36,10 +38,40 @@ import (
 ```go
     cfg := clientcredentials.Config{
         ClientID: "your client id",
+        AuthStyle: oauth2.AuthStylePrivateKeyJWT,
     	PrivateKeyAuth: advancedauth.PrivateKeyAuth{
     		Key:   "your PEM encoded private key",
     		Alg:   advancedauth.RS256,
     		Exp:   30 * time.Second,
+    	},
+    }
+
+    token, err := cfg.Token(context.Background())
+```
+
+### TLS Auth
+
+Both `tls_client_auth` and `self_signed_tls_client_auth` are handled with `TLSAuth`
+
+#### Client credentials
+
+```go
+import (
+	"context"
+	"time"
+
+	"github.com/cloudentity/oauth2/advancedauth"
+	"github.com/cloudentity/oauth2/clientcredentials"
+)
+```
+
+```go
+    cfg := clientcredentials.Config{
+        ClientID: "your client id",
+        AuthStyle: oauth2.AuthStyleTLS,
+    	TLSAuth: advancedauth.TLSAuth{
+    		Key:   "your certificate PEM encoded private key",
+    		Certificate:   "your PEM encoded TLS certificate",
     	},
     }
 

--- a/advancedauth/advancedauth.go
+++ b/advancedauth/advancedauth.go
@@ -1,6 +1,7 @@
 package advancedauth
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/cloudentity/oauth2"
@@ -22,6 +23,7 @@ type Config struct {
 	AuthStyle      oauth2.AuthStyle
 	ClientID       string
 	PrivateKeyAuth PrivateKeyAuth
+	TLSAuth        TLSAuth
 	TokenURL       string
 }
 
@@ -38,5 +40,15 @@ func ExtendUrlValues(v url.Values, c Config) error {
 			}
 		}
 	}
+	if c.AuthStyle == oauth2.AuthStyleTLS {
+		v.Set("client_id", c.ClientID)
+	}
 	return nil
+}
+
+func ExtendContext(ctx context.Context, c Config) (context.Context, error) {
+	if c.AuthStyle == oauth2.AuthStyleTLS {
+		return extendContextWithTLSClient(ctx, c)
+	}
+	return ctx, nil
 }

--- a/advancedauth/tls.go
+++ b/advancedauth/tls.go
@@ -1,0 +1,49 @@
+package advancedauth
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+
+	"github.com/cloudentity/oauth2"
+)
+
+type TLSAuth struct {
+	// Key is the private key for client TLS certificate
+	Key string
+	// Certificate is the client TLS certificate
+	Certificate string
+}
+
+func extendContextWithTLSClient(ctx context.Context, c Config) (context.Context, error) {
+	var (
+		hc   *http.Client
+		ok   bool
+		cert tls.Certificate
+		err  error
+		tr   *http.Transport
+	)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if hc, ok = ctx.Value(oauth2.HTTPClient).(*http.Client); !ok {
+		hc = http.DefaultClient
+	}
+
+	if cert, err = tls.X509KeyPair([]byte(c.TLSAuth.Certificate), []byte(c.TLSAuth.Key)); err != nil {
+		return nil, err
+	}
+
+	if tr, ok = hc.Transport.(*http.Transport); !ok {
+		tr = &http.Transport{}
+	}
+	if tr.TLSClientConfig == nil {
+		tr.TLSClientConfig = &tls.Config{}
+	}
+	tr.TLSClientConfig.Certificates = []tls.Certificate{cert}
+	hc.Transport = tr
+
+	return context.WithValue(ctx, oauth2.HTTPClient, hc), nil
+
+}

--- a/advancedauth/tls_test.go
+++ b/advancedauth/tls_test.go
@@ -1,0 +1,143 @@
+package advancedauth_test
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/cloudentity/oauth2"
+	"github.com/cloudentity/oauth2/advancedauth"
+	"github.com/cloudentity/oauth2/clientcredentials"
+)
+
+const (
+	key = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC0uhESy4URdqwo
+8Hbus5UjdxQom0zQj7jw4bcZ2Z4X0HLJbmbDZdwIaoOWfSjYu9VYPkE04/+KnBOh
+XMpA8DfcyS+XVPPTAEFI7KH9RF7BTMjSxB32Huwz9hMHqiPxJx1R+dTSWSC61+GX
+Dq+cLHGeQq4Cqxxf0nnGmgpnT26GtiG/QZzE0IdlxaK68BzFk3syNzVFE8Om6yzx
+ET7L5/p6igFrj22enjbYimtcSuHM2k16n0MSipBL2v1scheifGN0P+po118IRuX2
+mU8WH5Z8eyInWf857sNEHuFoCkuegJFVkzkuzxZz/F+cT1Znfq0x17ssnL9SFDk4
+XpyNKTqPAgMBAAECggEAULaMq30zV8JNTxddtmuDnswut5fsLXUSnpnf4W6cOXyB
+1040HO4f365aSFprZKg2tutOyeVNmkTsS3OabHgcKsG7PHXXUxPZFE2CZw8i1meJ
+hP/LdcEHsokipJiq5qeWY6cVEkB16pxBhuorKa97qreS6WQsDut8MWNYZB1Iemaa
+HjioQZ7SpUUUyr3XNuvoaPViymGou6DYLaIMg0zklOrfigu1Qb4XdtWtbdi3AWcr
+dVNO/N8Y19pJGqpJZ0FlqT/G8es10prAJGPAy4O/RxsLEfOSlZHe1Oj5V63B5h6R
+KPwzSRM03gqHG0qruhr2seQN2UvJSRJNz3a2q7siGQKBgQDsXvcohxXoVkv2yvq4
+D9QmQxU3/zHPZhnFNpZ9p3a4AHvmTFyTErTPrZn+QW/l9VvyKGctezR9/SMTLmsQ
+dz8Pnbqoukp2Vo/zNK1HEf3Iy5/lVZtd4ErfFCKpWYkNEXX43RQ2qvNt/XkkuIIg
+mijoKxBfiwKD8sGB2B8owHCi6wKBgQDDvCglc1yPQ3dzEcaMOoABKWdH7Q72Xgjr
+rpmO5lATn6kvcwgAjf/EEIGSQVjoY3zhOZ4J/eV7G6NTg9sRVhcWtkt1UtVv1BwE
+Cg4P6W7hCg8GF8Egh/dYtarx19juZkXk5HNSe0PEgrpbjzdxx0s/2HE1JwziVa3q
+qJFV4gd17QKBgQCS81dlctZD46LGg9rro6uZPgtrDNTCxA8xdIaLCBneuy5MNx02
+smKG2r7qO3R92tSW8Fd1ByvTSBUOT8VwLzKdWso5K9gvShGkehNgI+dLdoyp31cA
+PflORw5liqyR21Ekrw1qD03YC8XM9oiwDCdyb5N2Us31im6TcvGsPDfKkQKBgQCF
+Ok0ZMKyP1xw29qJuUGNQZx4llvXYO6lWwkFDQwC+Wq6N3X5U4lJ04cdQBaq+gvk9
+VDp+EpNgeC9zaQxzgGW2z94MvZUJyRZIqY9oxTrzciVHwGN0ARgbCYyRkJnXq0Vn
+xxe3zK8T0ueF6rWSfFR74Jct1qauaCM41gQWsQLjAQKBgGfnF99nLe1iI4AZgLIQ
+nYgCV65/bmbgX5gkMbDMxZzZYNWg15YuB5Ir+cf20pCwO5EmoLpn7KGpEeED4+/z
+2PZrF4bcjmEhYT5O2Y1Wn1oB84uug9c+ME7yiU30g1FttURZuLtzUxASFP2o0l7r
+zbSntKWbvm2qk39YKulrEnoh
+-----END PRIVATE KEY-----`
+	cert = `-----BEGIN CERTIFICATE-----
+MIIDHTCCAgUCFE+Ha5QgryApfoCjSX564o0JoGYIMA0GCSqGSIb3DQEBCwUAMCcx
+CzAJBgNVBAYTAlVTMRgwFgYDVQQDDA9FeGFtcGxlLVJvb3QtQ0EwIBcNMjIxMDMx
+MTgxODQ0WhgPMjA3NzA4MDMxODE4NDRaMG0xCzAJBgNVBAYTAlVTMRIwEAYDVQQI
+DAlZb3VyU3RhdGUxETAPBgNVBAcMCFlvdXJDaXR5MR0wGwYDVQQKDBRFeGFtcGxl
+LUNlcnRpZmljYXRlczEYMBYGA1UEAwwPbG9jYWxob3N0LmxvY2FsMIIBIjANBgkq
+hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtLoREsuFEXasKPB27rOVI3cUKJtM0I+4
+8OG3GdmeF9ByyW5mw2XcCGqDln0o2LvVWD5BNOP/ipwToVzKQPA33Mkvl1Tz0wBB
+SOyh/URewUzI0sQd9h7sM/YTB6oj8ScdUfnU0lkgutfhlw6vnCxxnkKuAqscX9J5
+xpoKZ09uhrYhv0GcxNCHZcWiuvAcxZN7Mjc1RRPDpuss8RE+y+f6eooBa49tnp42
+2IprXErhzNpNep9DEoqQS9r9bHIXonxjdD/qaNdfCEbl9plPFh+WfHsiJ1n/Oe7D
+RB7haApLnoCRVZM5Ls8Wc/xfnE9WZ36tMde7LJy/UhQ5OF6cjSk6jwIDAQABMA0G
+CSqGSIb3DQEBCwUAA4IBAQCBeRGIRS2MljdbgExv5KEND4OhEj2kuuES1zzTQjgs
+EO6G3RlFRU9dFz9WDsLSeegY/4Y8BwR6kA3IpmLVnfmn4odWHhLv+JCDo7TG+R6c
+3JnHbLuimcMLnGVVdUzAxQz09bNxYhCqUEla/ji0GeSxg8j8ofxtE7qihODV5dQv
+gx3Ef/WxZTy08hd8pKxA8dg/VzechNRngFpINXUnGsX699pSoPWfHQoyZprvWjE7
+QDac6VgTzy/KPfaf9vi3MiXJyjJOuGO3+SL1PhR712qRGg9Y+kccNUlL4OfrLJpm
+qobZlvUYUfAYcyJVtjas3vPoQHVCcbq7hdbso5FrLyPK
+-----END CERTIFICATE-----`
+)
+
+func TestTLS_ClientCredentials(t *testing.T) {
+	tcs := []struct {
+		title  string
+		config clientcredentials.Config
+	}{
+		{
+			title: "TLS",
+			config: clientcredentials.Config{
+				ClientID:  "CLIENT_ID",
+				AuthStyle: oauth2.AuthStyleTLS,
+				TLSAuth: advancedauth.TLSAuth{
+					Key:         key,
+					Certificate: cert,
+				},
+				Scopes:         []string{"scope1", "scope2"},
+				EndpointParams: url.Values{"audience": {"audience1"}},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.title, func(tt *testing.T) {
+			var serverURL string
+
+			ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				expectURL(tt, r, "/token")
+				expectHeader(tt, r, "Authorization", "")
+				expectHeader(tt, r, "Content-Type", "application/x-www-form-urlencoded")
+				expectFormParam(tt, r, "client_id", "CLIENT_ID")
+				expectFormParam(tt, r, "client_secret", "")
+				expectFormParam(tt, r, "grant_type", "client_credentials")
+
+				cert := r.TLS.PeerCertificates[0]
+				expectStringsEqual(tt, "Example-Root-CA", cert.Issuer.CommonName)
+
+				w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+				_, err := w.Write([]byte("access_token=90d64460d14870c08c81352a05dedd3465940a7c&token_type=bearer"))
+				if err != nil {
+					tt.Errorf("could not write body")
+				}
+			}))
+
+			ts.TLS = &tls.Config{
+				ClientAuth: tls.RequestClientCert,
+			}
+
+			ts.StartTLS()
+			serverURL = ts.URL
+			defer ts.Close()
+			conf := tc.config
+			conf.TokenURL = serverURL + "/token"
+
+			_, err := conf.Token(context.Background())
+			// context.Background() will fail as the server cert is not trusted
+			// err == nil checks if there are no panics
+			if err == nil {
+				tt.Errorf("expected Token to fail with invalid server cert")
+			}
+
+			client := ts.Client()
+			ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
+			tok, err := conf.Token(ctx)
+			if err != nil {
+				tt.Error(err)
+			}
+
+			expectAccessToken(tt, &oauth2.Token{
+				AccessToken:  "90d64460d14870c08c81352a05dedd3465940a7c",
+				TokenType:    "bearer",
+				RefreshToken: "",
+				Expiry:       time.Time{},
+			}, tok)
+		})
+	}
+
+}

--- a/advancedauth/utils_test.go
+++ b/advancedauth/utils_test.go
@@ -11,14 +11,14 @@ import (
 func expectHeader(t *testing.T, r *http.Request, header string, expected string) {
 	actual := r.Header.Get(header)
 	if actual != expected {
-		t.Errorf("Expected header %s to be %s, got %s", header, expected, actual)
+		t.Fatalf("Expected header %s to be %s, got %s", header, expected, actual)
 	}
 }
 
 func expectURL(t *testing.T, r *http.Request, expected string) {
 	actual := r.URL.String()
 	if actual != expected {
-		t.Errorf("Expected url to be %s, got %s", expected, actual)
+		t.Fatalf("Expected url to be %s, got %s", expected, actual)
 	}
 }
 
@@ -28,11 +28,11 @@ func expectBody(t *testing.T, r *http.Request, expected string) {
 		r.Body.Close()
 	}
 	if err != nil {
-		t.Errorf("failed reading request body: %s.", err)
+		t.Fatalf("failed reading request body: %s.", err)
 	}
 	actual := string(body)
 	if actual != expected {
-		t.Errorf("Expected body to be %s, got %s", expected, actual)
+		t.Fatalf("Expected body to be %s, got %s", expected, actual)
 	}
 }
 
@@ -41,34 +41,34 @@ func expectAccessToken(t *testing.T, expected *oauth2.Token, actual *oauth2.Toke
 		t.Fatalf("token invalid. got: %+v", actual)
 	}
 	if actual.AccessToken != expected.AccessToken {
-		t.Errorf("Access token = %q; want %q", actual.AccessToken, expected.AccessToken)
+		t.Fatalf("Access token = %q; want %q", actual.AccessToken, expected.AccessToken)
 	}
 	if actual.TokenType != expected.TokenType {
-		t.Errorf("token type = %q; want %q", actual.TokenType, expected.TokenType)
+		t.Fatalf("token type = %q; want %q", actual.TokenType, expected.TokenType)
 	}
 }
 
 func expectFormParam(t *testing.T, r *http.Request, param string, expected string) {
 	actual := r.FormValue(param)
 	if actual != expected {
-		t.Errorf("Expected form param %s to be %s, got %s", param, expected, actual)
+		t.Fatalf("Expected form param %s to be %s, got %s", param, expected, actual)
 	}
 }
 
 func expectStringsEqual(t *testing.T, expected string, actual string) {
 	if actual != expected {
-		t.Errorf("Expected %s and %s to be equal", expected, actual)
+		t.Fatalf("Expected %s and %s to be equal", expected, actual)
 	}
 }
 
 func expectStringNonEmpty(t *testing.T, actual string) {
 	if actual == "" {
-		t.Errorf("Expected not empty %s", actual)
+		t.Fatalf("Expected not empty %s", actual)
 	}
 }
 
 func expectTrue(t *testing.T, actual bool) {
 	if !actual {
-		t.Errorf("Expected true %t", actual)
+		t.Fatalf("Expected true %t", actual)
 	}
 }

--- a/oauth2.go
+++ b/oauth2.go
@@ -102,6 +102,9 @@ const (
 	// signed using the private key
 	// described in OpenID Connect Core
 	AuthStylePrivateKeyJWT AuthStyle = 3
+
+	// AuthStyleTLS
+	AuthStyleTLS AuthStyle = 4
 )
 
 var (


### PR DESCRIPTION
This PR adds TLS client authentication support - `tls_client_auth` and `self_signed_tls_client_auth` auth methods.

## Implementation details

Original library uses `oauth2.HTTPClient` stored in the context when making calls to the `token` endpoint.
This PR sets appropriate tls client certificate if the client already exists, if not, it creates a default client with tls cert.