### PR TITLE
Authorization code Exchange support for private_key_jwt and tls_client_auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cloudentity/oauth2"
 	"github.com/cloudentity/oauth2/advancedauth"
 	"github.com/cloudentity/oauth2/clientcredentials"
 )
@@ -39,14 +40,44 @@ import (
     cfg := clientcredentials.Config{
         ClientID: "your client id",
         AuthStyle: oauth2.AuthStylePrivateKeyJWT,
-    	PrivateKeyAuth: advancedauth.PrivateKeyAuth{
-    		Key:   "your PEM encoded private key",
-    		Alg:   advancedauth.RS256,
-    		Exp:   30 * time.Second,
-    	},
+        PrivateKeyAuth: advancedauth.PrivateKeyAuth{
+    		Key:         "your PEM encoded private key",
+    		Algorithm:   advancedauth.RS256,
+    		Exp:         30 * time.Second,
+        },
     }
 
     token, err := cfg.Token(context.Background())
+```
+
+#### Authorization code
+
+```go
+import (
+	"context"
+	"time"
+
+	"github.com/cloudentity/oauth2"
+	"github.com/cloudentity/oauth2/advancedauth"
+)
+```
+
+```go
+
+    cfg := oauth2.Config{
+        ClientID: "your client id",
+        Endpoint: oauth2.Endpoint{
+            AuthStyle: oauth2.AuthStylePrivateKeyJWT,
+        },
+        PrivateKeyAuth: advancedauth.PrivateKeyAuth{
+    		Key:         "your PEM encoded private key",
+    		Algorithm:   advancedauth.RS256,
+    		Exp:         30 * time.Second,
+        },
+        Scopes: []string{"scope1", "scope2"},
+    },
+
+    token, err := cfg.Exchange(context.Background(), "your authorization code")
 ```
 
 ### TLS Auth
@@ -60,6 +91,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cloudentity/oauth2"
 	"github.com/cloudentity/oauth2/advancedauth"
 	"github.com/cloudentity/oauth2/clientcredentials"
 )
@@ -76,6 +108,35 @@ import (
     }
 
     token, err := cfg.Token(context.Background())
+```
+
+#### Authorization code
+
+```go
+import (
+	"context"
+	"time"
+
+	"github.com/cloudentity/oauth2"
+	"github.com/cloudentity/oauth2/advancedauth"
+)
+```
+
+```go
+
+    cfg := oauth2.Config{
+        ClientID: "your client id",
+        Endpoint: oauth2.Endpoint{
+            AuthStyle: oauth2.AuthStyleTLS,
+        },
+    	TLSAuth: advancedauth.TLSAuth{
+    		Key:   "your certificate PEM encoded private key",
+    		Certificate:   "your PEM encoded TLS certificate",
+    	},
+        Scopes: []string{"scope1", "scope2"},
+    },
+
+    token, err := cfg.Exchange(context.Background(), "your authorization code")
 ```
 
 ## Implementation

--- a/advancedauth/tls.go
+++ b/advancedauth/tls.go
@@ -5,8 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"net/http"
-
-	"github.com/cloudentity/oauth2"
 )
 
 type TLSAuth struct {
@@ -16,7 +14,7 @@ type TLSAuth struct {
 	Certificate string
 }
 
-func extendContextWithTLSClient(ctx context.Context, c Config) (context.Context, error) {
+func extendContextWithTLSClient(ctx context.Context, httpClientContextKey interface{}, c Config) (context.Context, error) {
 	var (
 		hc   *http.Client
 		ok   bool
@@ -28,9 +26,9 @@ func extendContextWithTLSClient(ctx context.Context, c Config) (context.Context,
 		ctx = context.Background()
 	}
 
-	if ctx.Value(oauth2.HTTPClient) == nil {
+	if ctx.Value(httpClientContextKey) == nil {
 		hc = http.DefaultClient
-	} else if hc, ok = ctx.Value(oauth2.HTTPClient).(*http.Client); !ok {
+	} else if hc, ok = ctx.Value(httpClientContextKey).(*http.Client); !ok {
 		return nil, errors.New("client of type *http.Client required in context")
 	}
 
@@ -49,6 +47,6 @@ func extendContextWithTLSClient(ctx context.Context, c Config) (context.Context,
 	tr.TLSClientConfig.Certificates = []tls.Certificate{cert}
 	hc.Transport = tr
 
-	return context.WithValue(ctx, oauth2.HTTPClient, hc), nil
+	return context.WithValue(ctx, httpClientContextKey, hc), nil
 
 }

--- a/advancedauth/tls_test.go
+++ b/advancedauth/tls_test.go
@@ -95,6 +95,7 @@ func TestTLS_ClientCredentials(t *testing.T) {
 				expectHeader(tt, r, "Content-Type", "application/x-www-form-urlencoded")
 				expectFormParam(tt, r, "client_id", "CLIENT_ID")
 				expectFormParam(tt, r, "client_secret", "")
+				expectFormParam(tt, r, "scope", "scope1 scope2")
 				expectFormParam(tt, r, "grant_type", "client_credentials")
 
 				cert := r.TLS.PeerCertificates[0]
@@ -127,6 +128,86 @@ func TestTLS_ClientCredentials(t *testing.T) {
 			client := ts.Client()
 			ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
 			tok, err := conf.Token(ctx)
+			if err != nil {
+				tt.Error(err)
+			}
+
+			expectAccessToken(tt, &oauth2.Token{
+				AccessToken:  "90d64460d14870c08c81352a05dedd3465940a7c",
+				TokenType:    "bearer",
+				RefreshToken: "",
+				Expiry:       time.Time{},
+			}, tok)
+		})
+	}
+
+}
+
+func TestTLS_Exchange(t *testing.T) {
+	tcs := []struct {
+		title  string
+		config oauth2.Config
+	}{
+		{
+			title: "TLS",
+			config: oauth2.Config{
+				ClientID: "CLIENT_ID",
+				Endpoint: oauth2.Endpoint{
+					AuthStyle: oauth2.AuthStyleTLS,
+				},
+				TLSAuth: advancedauth.TLSAuth{
+					Key:         key,
+					Certificate: cert,
+				},
+				Scopes: []string{"scope1", "scope2"},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.title, func(tt *testing.T) {
+			var serverURL string
+
+			ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				expectURL(tt, r, "/token")
+				expectHeader(tt, r, "Authorization", "")
+				expectHeader(tt, r, "Content-Type", "application/x-www-form-urlencoded")
+				expectFormParam(tt, r, "client_id", "CLIENT_ID")
+				expectFormParam(tt, r, "client_secret", "")
+				expectFormParam(tt, r, "scope", "")
+				expectFormParam(tt, r, "grant_type", "authorization_code")
+
+				cert := r.TLS.PeerCertificates[0]
+				expectStringsEqual(tt, "Example-Root-CA", cert.Issuer.CommonName)
+
+				w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+				_, err := w.Write([]byte("access_token=90d64460d14870c08c81352a05dedd3465940a7c&token_type=bearer"))
+				if err != nil {
+					tt.Errorf("could not write body")
+				}
+			}))
+
+			ts.TLS = &tls.Config{
+				ClientAuth: tls.RequestClientCert,
+			}
+
+			ts.StartTLS()
+			serverURL = ts.URL
+			defer ts.Close()
+			conf := tc.config
+			conf.Endpoint.TokenURL = serverURL + "/token"
+
+			_, err := conf.Exchange(context.Background(), "random")
+			// context.Background() will fail as the server cert is not trusted
+			// err == nil checks if there are no panics
+			if err == nil {
+				tt.Errorf("expected Token to fail with invalid server cert")
+			}
+
+			client := ts.Client()
+			ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
+			tok, err := conf.Exchange(ctx, "random")
 			if err != nil {
 				tt.Error(err)
 			}
@@ -226,12 +307,12 @@ func TestExtendContext(t *testing.T) {
 		tc := tc
 		t.Run(tc.title, func(tt *testing.T) {
 			config := advancedauth.Config{
-				AuthStyle: oauth2.AuthStyleTLS,
+				AuthStyle: advancedauth.AuthStyleTLS,
 				ClientID:  "random",
 				TLSAuth:   tc.auth,
 				TokenURL:  "random",
 			}
-			ctx, err := advancedauth.ExtendContext(tc.ctx, config)
+			ctx, err := advancedauth.ExtendContext(tc.ctx, oauth2.HTTPClient, config)
 			if tc.errorExpected && err == nil {
 				tt.Errorf("expected error")
 			} else if !tc.errorExpected && err != nil {

--- a/advancedauth/tls_test.go
+++ b/advancedauth/tls_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 	"time"
 
@@ -78,8 +77,7 @@ func TestTLS_ClientCredentials(t *testing.T) {
 					Key:         key,
 					Certificate: cert,
 				},
-				Scopes:         []string{"scope1", "scope2"},
-				EndpointParams: url.Values{"audience": {"audience1"}},
+				Scopes: []string{"scope1", "scope2"},
 			},
 		},
 	}

--- a/clientcredentials/clientcredentials.go
+++ b/clientcredentials/clientcredentials.go
@@ -107,7 +107,7 @@ func (c *tokenSource) Token() (*oauth2.Token, error) {
 	if c.conf.AuthStyle > 2 {
 		var err error
 		cfg := advancedauth.Config{
-			AuthStyle:      c.conf.AuthStyle,
+			AuthStyle:      advancedauth.AuthStyle(c.conf.AuthStyle),
 			ClientID:       c.conf.ClientID,
 			PrivateKeyAuth: c.conf.PrivateKeyAuth,
 			TLSAuth:        c.conf.TLSAuth,
@@ -116,7 +116,7 @@ func (c *tokenSource) Token() (*oauth2.Token, error) {
 		if err = advancedauth.ExtendUrlValues(v, cfg); err != nil {
 			return nil, err
 		}
-		if c.ctx, err = advancedauth.ExtendContext(c.ctx, cfg); err != nil {
+		if c.ctx, err = advancedauth.ExtendContext(c.ctx, oauth2.HTTPClient, cfg); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
This PR adds support for `private_key_jwt`, `tls_client_auth` and `self_signed_tls_client_auth` for `authorization_code` `Exchange` method.

The code is based on previously added `client_credentials` support.

Note:
To avoid import cycles, I'm pushing `oauth2.Client` to the `advanced` package as an interface{}.
Additionally, there's a conversion between `oauth2.AuthStyle` and `advancedauth.AuthStyle`