### PR TITLE
Sync

### DIFF
--- a/google/default.go
+++ b/google/default.go
@@ -37,6 +37,21 @@ type Credentials struct {
 	// environment and not with a credentials file, e.g. when code is
 	// running on Google Cloud Platform.
 	JSON []byte
+
+	// UniverseDomainProvider returns the default service domain for a given
+	// Cloud universe. Optional.
+	//
+	// On GCE, UniverseDomainProvider should return the universe domain value
+	// from Google Compute Engine (GCE)'s metadata server. See also [The attached service
+	// account](https://cloud.google.com/docs/authentication/application-default-credentials#attached-sa).
+	// If the GCE metadata server returns a 404 error, the default universe
+	// domain value should be returned. If the GCE metadata server returns an
+	// error other than 404, the error should be returned.
+	UniverseDomainProvider func() (string, error)
+}
+
+func (c *Credentials) GetUniverseDomain() (string, error) {
+	return "", nil
 }
 
 // DefaultCredentials is the old name of Credentials.

--- a/internal/token.go
+++ b/internal/token.go
@@ -324,8 +324,11 @@ func doTokenRoundTrip(ctx context.Context, req *http.Request) (*Token, error) {
 }
 
 type RetrieveError struct {
-	Response *http.Response
-	Body     []byte
+	Response         *http.Response
+	Body             []byte
+	ErrorCode        string
+	ErrorDescription string
+	ErrorURI         string
 }
 
 func (r *RetrieveError) Error() string {

--- a/token.go
+++ b/token.go
@@ -181,6 +181,12 @@ type RetrieveError struct {
 	// Body is the body that was consumed by reading Response.Body.
 	// It may be truncated.
 	Body []byte
+	// ErrorCode is RFC 6749's 'error' parameter.
+	ErrorCode string
+	// ErrorDescription is RFC 6749's 'error_description' parameter.
+	ErrorDescription string
+	// ErrorURI is RFC 6749's 'error_uri' parameter.
+	ErrorURI string
 }
 
 func (r *RetrieveError) Error() string {


### PR DESCRIPTION
```
# cloud.google.com/go/auth/oauth2adapt
../../go/pkg/mod/cloud.google.com/go/auth/oauth2adapt@v0.2.4/oauth2adapt.go:99:17: creds.GetUniverseDomain undefined (type *google.Credentials has no field or method GetUniverseDomain)
../../go/pkg/mod/cloud.google.com/go/auth/oauth2adapt@v0.2.4/oauth2adapt.go:118:3: unknown field UniverseDomainProvider in struct literal of type google.Credentials
../../go/pkg/mod/cloud.google.com/go/auth/oauth2adapt@v0.2.4/oauth2adapt.go:146:5: e.ErrorCode undefined (type *oauth2.RetrieveError has no field or method ErrorCode)
../../go/pkg/mod/cloud.google.com/go/auth/oauth2adapt@v0.2.4/oauth2adapt.go:147:5: e.ErrorDescription undefined (type *oauth2.RetrieveError has no field or method ErrorDescription)
../../go/pkg/mod/cloud.google.com/go/auth/oauth2adapt@v0.2.4/oauth2adapt.go:148:5: e.ErrorURI undefined (type *oauth2.RetrieveError has no field or method ErrorURI)
```