### PR TITLE
Serialize aud claim to string if it contains only single value

### DIFF
--- a/advancedauth/privatekeyjwt.go
+++ b/advancedauth/privatekeyjwt.go
@@ -12,6 +12,10 @@ import (
 
 const privateKeyJWTAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
+func init() {
+	jwt.MarshalSingleStringAsArray = false
+}
+
 type PrivateKeyAuth struct {
 	// Key is a PEM formatted private key used to sign client_assertion
 	Key string


### PR DESCRIPTION
This change is needed to address the Audience.Injection vulnerability: https://datatracker.ietf.org/doc/draft-ietf-oauth-rfc7523bis

Before, in the `private_key_jwt` assertion JWT, if the audience claim was `[]string{"123"}` - it was serialized as `"aud": ["123"]`.
After this change, it will be serialized as `"aud": "123"` if the Audience claim contains only a single value.
